### PR TITLE
Add Subject Alternative Names (SAN) to server certificate generation

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"time"
+)
+
+func main() {
+
+	// サーバーの証明書を読み込む
+	cert, err := os.ReadFile("certs/server.crt")
+	if err != nil {
+		log.Fatal("🚨 サーバーの証明書を読み込めませんでした。", err)
+	}
+
+	// CA証明書を信頼するよう設定
+	caCertPool := x509.NewCertPool()
+	if !caCertPool.AppendCertsFromPEM(cert) {
+		log.Fatal("🚨 CA証明書を信頼できませんでした。")
+	}
+
+	// TLS1.3のみを使用する。
+	tlsConfig := &tls.Config{
+		MinVersion: tls.VersionTLS13,
+		RootCAs:    caCertPool, // CA証明書を信頼するよう設定
+	}
+
+	tr := &http.Transport{
+		TLSClientConfig: tlsConfig,
+	}
+
+	client := &http.Client{
+		Transport: tr,
+		Timeout:   10 * time.Second, // タイムアウト設定
+	}
+
+	// サーバーにGETリクエストを送信
+	resp, err := client.Get("https://localhost:8443")
+	if err != nil {
+		log.Fatal("🚨 サーバーに接続できませんでした。", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal("🚨 レスポンスの読み込みに失敗しました。", err)
+	}
+	// レスポンスのステータスコードを確認
+	log.Printf("Response status: %d", resp.StatusCode)
+	log.Printf("Response body: %s", string(body))
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -19,7 +19,7 @@ func getTLSConfig() *tls.Config {
 		PreferServerCipherSuites: true, // サーバーの暗号スイートを優先
 		GetConfigForClient: func(clientHello *tls.ClientHelloInfo) (*tls.Config, error) {
 			// どの暗号スイートが選択されたかを確認
-			log.Printf("Client connected with TLS version: %x, Cipher Suite: %x",
+			log.Printf("🚀 クライアント接続: TLS version: %x, Cipher Suite: %x",
 				clientHello.SupportedVersions, clientHello.CipherSuites)
 			return nil, nil
 		},

--- a/scripts/generate_certs.sh
+++ b/scripts/generate_certs.sh
@@ -4,6 +4,30 @@
 mkdir -p certs
 cd certs
 
+# SANs設定ファイルの作成
+cat > san.cnf << EOF
+[req]
+distinguished_name = req_distinguished_name
+req_extensions = v3_req
+prompt = no
+
+[req_distinguished_name]
+C = JP
+ST = Tokyo
+L = Tokyo
+O = TLS Learning
+CN = localhost
+
+[v3_req]
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = localhost
+IP.1 = 127.0.0.1
+EOF
+
 # CA証明書の生成
 openssl req -x509 -newkey rsa:4096 -days 365 -nodes \
   -keyout ca.key -out ca.crt \
@@ -12,11 +36,12 @@ openssl req -x509 -newkey rsa:4096 -days 365 -nodes \
 # サーバー証明書の生成
 openssl req -newkey rsa:4096 -nodes \
   -keyout server.key -out server.csr \
-  -subj "/C=JP/ST=Tokyo/L=Tokyo/O=TLS Learning/CN=localhost"
+  -config san.cnf
 
 openssl x509 -req -days 365 \
   -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial \
-  -out server.crt
+  -out server.crt \
+  -extfile san.cnf -extensions v3_req
 
 # クライアント証明書の生成
 openssl req -newkey rsa:4096 -nodes \
@@ -27,7 +52,7 @@ openssl x509 -req -days 365 \
   -in client.csr -CA ca.crt -CAkey ca.key -CAcreateserial \
   -out client.crt
 
-# CSRファイルの削除
-rm *.csr
+# 不要なファイルの削除
+rm *.csr san.cnf
 
 echo "証明書の生成が完了しました。" 


### PR DESCRIPTION
## GoでのTLS 1.3通信クライアントの作成

### 概要

TLS 1.3を用いた安全なHTTPクライアントを実装。クライアントはサーバーの証明書を検証し、TLSの挙動を確認することが可能。

### 実装のポイント

1. **証明書の読み込み**:
   - サーバーの証明書をファイルから読み込み、CA証明書として信頼する設定を行います。

2. **TLS設定**:
   - `tls.Config`を使用して、TLS 1.3のみを使用するように設定します。
   - `RootCAs`にCA証明書を設定し、サーバー証明書の検証を行います。

3. **HTTPクライアントの設定**:
   - `http.Transport`にTLS設定を適用し、`http.Client`を作成します。
   - タイムアウトを設定し、サーバーへのGETリクエストを送信します。

4. **レスポンスの処理**:
   - サーバーからのレスポンスを受け取り、ステータスコードとボディをログに出力します。

### 学習のポイント

- **TLS 1.3の利用**:
  - 最新のTLSバージョンを使用することで、セキュリティを強化できます。TLS 1.3は、パフォーマンスの向上とセキュリティの強化が図られています。

- **証明書の検証**:
  - サーバーの証明書を正しく検証することは、MITM攻撃を防ぐために重要です。CA証明書を信頼する設定を行うことで、証明書の信頼性を確保します。

- **SANsの重要性**:
  - 証明書にSANs (Subject Alternative Names)を含めることで、複数のドメインやIPアドレスに対して証明書を有効にできます。これは、Common Nameフィールドに依存しない現代的な証明書の使用法です。

- **エラーハンドリング**:
  - 各ステップでエラーハンドリングを行い、問題が発生した際に適切なログを出力することが重要です。

